### PR TITLE
Bobbing strength cvars

### DIFF
--- a/trunk/xrGame/EffectorBobbing.cpp
+++ b/trunk/xrGame/EffectorBobbing.cpp
@@ -11,6 +11,7 @@
 #define CROUCH_FACTOR	0.75f
 #define SPEED_REMINDER	5.f 
 
+float psBobMult = 1.0f;
 
 
 //////////////////////////////////////////////////////////////////////
@@ -69,17 +70,17 @@ BOOL CEffectorBobbing::ProcessCam(SCamEffectorInfo& info)
 
 		if(isActorAccelerated(dwMState, m_bZoomMode))
 		{
-			A	= m_fAmplitudeRun*k;
+			A	= m_fAmplitudeRun*k * psBobMult;
 			ST	= m_fSpeedRun*fTime*k;
 		}
 		else if(is_limping)
 		{
-			A	= m_fAmplitudeLimp*k;
+			A	= m_fAmplitudeLimp*k * psBobMult;
 			ST	= m_fSpeedLimp*fTime*k;
 		}
 		else
 		{
-			A	= m_fAmplitudeWalk*k;
+			A	= m_fAmplitudeWalk*k * psBobMult;
 			ST	= m_fSpeedWalk*fTime*k;
 		}
 	

--- a/trunk/xrGame/console_commands.cpp
+++ b/trunk/xrGame/console_commands.cpp
@@ -1608,6 +1608,8 @@ public:
 	  }
 };
 
+extern float psBobMult;
+extern float psWpnBobMult;
 
 void CCC_RegisterCommands()
 {
@@ -1623,6 +1625,9 @@ void CCC_RegisterCommands()
 
 	CMD3(CCC_Mask,				"g_backrun",			&psActorFlags,	AF_RUN_BACKWARD);
 	CMD3(CCC_Mask,				"weapon_bobbing",		&psActorFlags,	AF_WPN_BOBBING);
+
+	CMD4(CCC_Float,				"bobbing_mult",			&psBobMult,		0.0f,	2.0f);
+	CMD4(CCC_Float,				"weapon_bobbing_mult",	&psWpnBobMult,	0.0f,	2.0f);
 
 	// alife
 #ifdef DEBUG

--- a/trunk/xrGame/weapon_bobbing.cpp
+++ b/trunk/xrGame/weapon_bobbing.cpp
@@ -10,6 +10,8 @@
 #include "weapon_bobbing.h"
 #include "actor.h"
 
+float psWpnBobMult = 1.0f;
+
 CWeaponBobbing::CWeaponBobbing()
 {
 	Load();
@@ -69,17 +71,17 @@ void CWeaponBobbing::Update(Fmatrix &m)
 
 		if (isActorAccelerated(dwMState, m_bZoomMode))
 		{
-			A	= m_fAmplitudeRun * k;
+			A	= m_fAmplitudeRun * k * psWpnBobMult;
 			ST	= m_fSpeedRun * fTime * k;
 		}
 		else if (is_limping)
 		{
-			A	= m_fAmplitudeLimp * k;
+			A	= m_fAmplitudeLimp * k * psWpnBobMult;
 			ST	= m_fSpeedLimp * fTime * k;
 		}
 		else
 		{
-			A	= m_fAmplitudeWalk * k;
+			A	= m_fAmplitudeWalk * k * psWpnBobMult;
 			ST	= m_fSpeedWalk * fTime * k;
 		}
 	


### PR DESCRIPTION
Adds `bobbing_mult` and `weapon_bobbing_mult` cvars, ranging from `0.0` to `2.0`.
The bob values from `effectors.ltx` are multiplied with the cvars' values.
This is an easy way for players to disable viewbobbing or adjust its strength without editing the ltx files.