### PR TITLE
Fix 60hz toggle & Stop forcing highest refresh rate

### DIFF
--- a/trunk/xrNetServer/NET_Client.cpp
+++ b/trunk/xrNetServer/NET_Client.cpp
@@ -237,7 +237,7 @@ void			INetQueue::Release	()
 
 //
 const u32 syncQueueSize		= 512;
-const int syncSamples		= 6;
+const int syncSamples		= 256;
 class XRNETSERVER_API syncQueue
 {
 	u32				table	[syncQueueSize];

--- a/trunk/xr_3da/HW.cpp
+++ b/trunk/xr_3da/HW.cpp
@@ -415,11 +415,12 @@ u32 CHW::selectGPU()
 
 u32 CHW::selectRefresh(u32 dwWidth, u32 dwHeight, D3DFORMAT fmt)
 {
-	if (psDeviceFlags.is(rsRefresh60hz))
+	if (!psDeviceFlags.is(rsRefresh60hz))
 		return D3DPRESENT_RATE_DEFAULT;
 	else
 	{
 		u32 selected	= D3DPRESENT_RATE_DEFAULT;
+		u32 target		= 60;
 		u32 count		= pD3D->GetAdapterModeCount(DevAdapter,fmt);
 		for (u32 I = 0; I < count; I++)
 		{
@@ -427,7 +428,7 @@ u32 CHW::selectRefresh(u32 dwWidth, u32 dwHeight, D3DFORMAT fmt)
 			pD3D->EnumAdapterModes(DevAdapter,fmt,I,&Mode);
 			if (Mode.Width == dwWidth && Mode.Height == dwHeight)
 			{
-				if (Mode.RefreshRate>selected)
+				if (Mode.RefreshRate>selected && Mode.RefreshRate<=target)
 					selected = Mode.RefreshRate;
 			}
 		}

--- a/trunk/xr_3da/x_ray.cpp
+++ b/trunk/xr_3da/x_ray.cpp
@@ -1286,7 +1286,7 @@ void CApplication::load_draw_internal()
 //draw level-specific screenshot
 		if(hLevelLogo){
 			Frect						r;
-			r.lt.set					(257,369);
+			r.lt.set					(256,368);
 			r.lt.x						+= offs;
 			r.lt.y						+= offs;
 			r.rb.add					(r.lt,Fvector2().set(512,256));


### PR DESCRIPTION
By default, the game used to pick highest refresh rate available from our Display, which can be problematic if somebody uses different refresh rates on their Desktop, causing alt+tab to be slow