### PR TITLE
Fixed grass jumping too abruptly after long play

### DIFF
--- a/trunk/layers/xrRender/DetailManager_VS.cpp
+++ b/trunk/layers/xrRender/DetailManager_VS.cpp
@@ -134,10 +134,19 @@ void CDetailManager::hw_Unload()
 
 void CDetailManager::hw_Render()
 {
+
+	// In hw_Render():
+    // Use a wrapped time value for ALL calculations
+    static float wrappedTime = 0.0f;
+    wrappedTime += Device.fTimeDelta; // Increment by frame delta
+    if (wrappedTime > 10000.0f) wrappedTime -= 10000.0f; // Keep in range
+	
 	// Render-prepare
 	Fvector4	dir1,dir2;
-	float		tm_rot1		= (PI_MUL_2*Device.fTimeGlobal/swing_current.rot1);
-	float		tm_rot2		= (PI_MUL_2*Device.fTimeGlobal/swing_current.rot2);
+	// Use wrappedTime instead of Device.fTimeGlobal everywhere
+    float tm_rot1 = (PI_MUL_2 * wrappedTime / swing_current.rot1);
+    float tm_rot2 = (PI_MUL_2 * wrappedTime / swing_current.rot2);
+    float wavePhase = wrappedTime * swing_current.speed;
 	dir1.set				(_sin(tm_rot1),0,_cos(tm_rot1),0).normalize().mul(swing_current.amp1);
 	dir2.set				(_sin(tm_rot2),0,_cos(tm_rot2),0).normalize().mul(swing_current.amp2);
 
@@ -147,14 +156,14 @@ void CDetailManager::hw_Render()
 	// Wave0
 	float		scale			=	1.f/float(quant);
 	Fvector4	wave;
-	wave.set				(1.f/5.f,		1.f/7.f,	1.f/3.f,	Device.fTimeGlobal*swing_current.speed);
+	wave.set(1.f / 5.f, 1.f / 7.f, 1.f / 3.f, wavePhase);
 	RCache.set_c			(&*hwc_consts,	scale,		scale,		ps_r__Detail_l_aniso,	ps_r__Detail_l_ambient);				// consts
 	RCache.set_c			(&*hwc_wave,	wave.div(PI_MUL_2));	// wave
 	RCache.set_c			(&*hwc_wind,	dir1);																					// wind-dir
 	hw_Render_dump			(&*hwc_array,	1, 0, c_hdr );
 
 	// Wave1
-	wave.set				(1.f/3.f,		1.f/7.f,	1.f/5.f,	Device.fTimeGlobal*swing_current.speed);
+	wave.set(1.f / 3.f, 1.f / 7.f, 1.f / 5.f, wavePhase);
 	RCache.set_c			(&*hwc_wave,	wave.div(PI_MUL_2));	// wave
 	RCache.set_c			(&*hwc_wind,	dir2);																					// wind-dir
 	hw_Render_dump			(&*hwc_array,	2, 0, c_hdr );

--- a/trunk/xrGame/UICursor.cpp
+++ b/trunk/xrGame/UICursor.cpp
@@ -136,10 +136,41 @@ void CUICursor::UpdateCursorPosition(int _dx, int _dy)
 
 void CUICursor::SetUICursorPosition(Fvector2 pos)
 {
-	vPos		= pos;
-	POINT		p;
-	p.x			= iFloor(vPos.x / (UI_BASE_WIDTH / (float)Device.dwWidth));
-	p.y			= iFloor(vPos.y / (UI_BASE_HEIGHT / (float)Device.dwHeight));
+	clamp(pos.x, 0.f, UI_BASE_WIDTH);
+	clamp(pos.y, 0.f, UI_BASE_HEIGHT);
 
-	SetCursorPos(p.x, p.y);
+	HWND hWnd = Device.m_hWnd;
+
+	// 1) Текущая клиентка
+	RECT rc{};
+	GetClientRect(hWnd, &rc);
+	const float cw = float(rc.right - rc.left);
+	const float ch = float(rc.bottom - rc.top);
+
+	// 2) UI -> клиентские пиксели
+	POINT cpt;
+	cpt.x = LONG(floorf(pos.x * (cw / UI_BASE_WIDTH) + 0.5f));
+	cpt.y = LONG(floorf(pos.y * (ch / UI_BASE_HEIGHT) + 0.5f));
+
+	// 4) Клиент -> экран и SetCursorPos
+	ClientToScreen(hWnd, &cpt);
+	SetCursorPos(cpt.x, cpt.y);
+
+	// 5) Жёсткая синхронизация внутренних координат (не ждать физдвижения)
+	if (m_b_use_win_cursor)
+	{
+		POINT pt{};
+		GetCursorPos(&pt);            // уже центр по экрану
+		ScreenToClient(hWnd, &pt);    // обратно в клиент
+		const float sx = UI_BASE_WIDTH / cw;
+		const float sy = UI_BASE_HEIGHT / ch;
+		vPrevPos.set(pos);
+		vPos.x = pt.x * sx;
+		vPos.y = pt.y * sy;
+	}
+	else
+	{
+		vPrevPos.set(pos);
+		vPos.set(pos);
+	}
 }

--- a/trunk/xrNetServer/NET_Client.cpp
+++ b/trunk/xrNetServer/NET_Client.cpp
@@ -237,7 +237,7 @@ void			INetQueue::Release	()
 
 //
 const u32 syncQueueSize		= 512;
-const int syncSamples		= 6;
+const int syncSamples		= 256;
 class XRNETSERVER_API syncQueue
 {
 	u32				table	[syncQueueSize];

--- a/trunk/xr_3da/x_ray.cpp
+++ b/trunk/xr_3da/x_ray.cpp
@@ -1286,7 +1286,7 @@ void CApplication::load_draw_internal()
 //draw level-specific screenshot
 		if(hLevelLogo){
 			Frect						r;
-			r.lt.set					(257,369);
+			r.lt.set					(256,368);
 			r.lt.x						+= offs;
 			r.lt.y						+= offs;
 			r.rb.add					(r.lt,Fvector2().set(512,256));


### PR DESCRIPTION
There is a common issue where after playing for some time grass starts to behave weirdly, wind waves change grass position too rapidly and abruptly. You can see it happening quickly using "time_factor 1000" command, then returning "time_factor" to 1. Grass will be broken. But it can happen in normal gameplay too as far as I have seen. It's an ugly graphics glitch which ruins an otherwise very pretty game.

It appears to be related to floating point error, and this fix appears to completely remove the issue.